### PR TITLE
Improve accessibility: Use rem units for font-size

### DIFF
--- a/src/styles/tabled_core.scss
+++ b/src/styles/tabled_core.scss
@@ -144,7 +144,7 @@ $breakpoint-large: 1024px;
       font-family: Arial, Helvetica, sans-serif;
       display: inline-block;
       content: "\2190";
-      font-size: 24px;
+      font-size: 1.5rem;
     }
 
     &:disabled {
@@ -159,7 +159,7 @@ $breakpoint-large: 1024px;
       font-family: Arial, Helvetica, sans-serif;
       display: inline-block;
       content: "\2192";
-      font-size: 24px;
+      font-size: 1.5rem;
     }
 
     &:disabled {


### PR DESCRIPTION
Improve accessibility: Use rem units for font-size in .tabled__previous and .tabled__next